### PR TITLE
Print version and sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,9 @@ ADD benchmarks /sightglass/benchmarks
 
 # Copy driver/helpers into the image
 WORKDIR /
+COPY wasmscore.sh /
 COPY wasmscore.py /sightglass/wasmscore.py
-COPY add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.sh wasmscore.py config.inc /
+COPY add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py config.inc /sightglass/
 
 # Set default entry and command
 ENTRYPOINT ["/bin/bash", "/wasmscore.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ADD benchmarks /sightglass/benchmarks
 # Copy driver/helpers into the image
 WORKDIR /
 COPY wasmscore.py /sightglass/wasmscore.py
-COPY wasmscore.sh /
+COPY add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.sh wasmscore.py config.inc /
 
 # Set default entry and command
 ENTRYPOINT ["/bin/bash", "/wasmscore.sh"]

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,8 @@ REVISION=$(echo $VERSION | cut -d '.' -f 3)
 BUILD_SHA=$(echo $VERSION | cut -d '.' -f 4)
 
 # Define current build and commit SHAs
-CURRENT_BUILD_SHA=$(find . -type f -name '*.wasm' | xargs -I{} sha1sum add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py {} | sha1sum | cut -c 1-7 | awk '{print $1}')
+# Sort -n/-h produced different sort results for inside vs outside the countainer so using sort -d
+CURRENT_BUILD_SHA=$(find . -type f -name '*.wasm' | sort -d | xargs -I{} sha1sum add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py {} | sha1sum | cut -c 1-7 | awk '{print $1}')
 
 # Define architecutre and kernel
 ARCH=$(uname -m | awk '{print tolower($0)}')

--- a/config.inc
+++ b/config.inc
@@ -1,2 +1,3 @@
 # Global variables used by scripts for docker building and launching
-IMAGE_VER="v0.1.0-alpha"
+IMAGE_NAME="wasmscore"
+IMAGE_VERSION="v0.1.1.e71fe01"

--- a/config.inc
+++ b/config.inc
@@ -1,3 +1,3 @@
 # Global variables used by scripts for docker building and launching
 IMAGE_NAME="wasmscore"
-IMAGE_VERSION="v0.1.1.e71fe01"
+IMAGE_VERSION="v0.1.1.54bbb97"

--- a/config.inc
+++ b/config.inc
@@ -1,3 +1,3 @@
 # Global variables used by scripts for docker building and launching
 IMAGE_NAME="wasmscore"
-IMAGE_VERSION="v0.1.1.54bbb97"
+IMAGE_VERSION="v0.1.1.63d6828"

--- a/wasmscore.py
+++ b/wasmscore.py
@@ -859,6 +859,11 @@ def main():
     print_verbose("")
     print_verbose("WasmScore")
 
+    config = open("./config.inc", "r")
+    for line in config:
+        print(line)
+    #find . -type f -name '*.wasm' | xargs -I{} sha1sum build.sh {} | sha1sum
+
     if ARGS_DICT["list"]:
         print("")
         print("Tests\n------")

--- a/wasmscore.py
+++ b/wasmscore.py
@@ -862,7 +862,7 @@ def check_version():
         stderr=subprocess.STDOUT,
     ).strip()
     calculated_build_version = subprocess.check_output(
-        "find . -type f -name '*.wasm' | xargs -I{} sha1sum add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py {} | sha1sum | cut -c 1-7 | awk '{print $1}'",
+        "find . -type f -name '*.wasm' | sort -d | xargs -I{} sha1sum add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py {} | sha1sum | cut -c 1-7 | awk '{print $1}'",
         shell=True,
         text=True,
         stderr=subprocess.STDOUT,

--- a/wasmscore.py
+++ b/wasmscore.py
@@ -853,16 +853,32 @@ def print_verbose(string):
     if not ARGS_DICT["quiet"]:
         print(string)
 
+def check_version():
+    """Check the version of the sightglass-cli"""
+    build_version = subprocess.check_output(
+        "grep 'IMAGE_VERSION' config.inc | cut -d '\"' -f 2 | cut -c 2- | cut -d '.' -f 4",
+        shell=True,
+        text=True,
+        stderr=subprocess.STDOUT,
+    ).strip()
+    calculated_build_version = subprocess.check_output(
+        "find . -type f -name '*.wasm' | xargs -I{} sha1sum add_time_metric.diff build.sh requirements.txt Dockerfile wasmscore.py {} | sha1sum | cut -c 1-7 | awk '{print $1}'",
+        shell=True,
+        text=True,
+        stderr=subprocess.STDOUT,
+    ).strip()
+    if (build_version == calculated_build_version):
+        print(f"Build SHA: {build_version} vs {calculated_build_version} (calculated) (run valid)")
+    else:
+        print(f"Build SHA: {build_version} vs {calculated_build_version} (calculated) (**run invalid**)")
+    return (build_version == calculated_build_version)
+
 
 def main():
     """Top level entry"""
     print_verbose("")
     print_verbose("WasmScore")
-
-    config = open("./config.inc", "r")
-    for line in config:
-        print(line)
-    #find . -type f -name '*.wasm' | xargs -I{} sha1sum build.sh {} | sha1sum
+    check_version()
 
     if ARGS_DICT["list"]:
         print("")


### PR DESCRIPTION
This updates adds a hash of most the files used for building and running wasmscore in order to check that has again inside the container at runtime. This way we can check if the stated build version is different from the version actually running.